### PR TITLE
Bugfix "Cannot assign null to property xaliSetting::$activation of type int

### DIFF
--- a/classes/Settings/class.xaliSetting.php
+++ b/classes/Settings/class.xaliSetting.php
@@ -51,6 +51,7 @@ class xaliSetting extends ActiveRecord
     /**
      * @db_has_field        true
      * @db_fieldtype        integer
+     * @db_is_notnull       true
      * @db_length           1
      */
     protected int $activation = 0;

--- a/plugin.php
+++ b/plugin.php
@@ -1,6 +1,6 @@
 <?php
 $id = 'xali';
-$version = "9.0.0";
+$version = "9.0.1";
 $ilias_min_version = '9.0';
 $ilias_max_version = '9.999';
 $responsible = "mbeym | mjansen";

--- a/sql/dbupdate.php
+++ b/sql/dbupdate.php
@@ -77,3 +77,14 @@ if (\srag\Plugins\AttendanceList\Libs\Notifications4Plugin\Notification\Reposito
 <?php
 \srag\Plugins\AttendanceList\Libs\Notifications4Plugin\Notification\Repository::getInstance()->installTables();
 ?>
+<#6>
+<?php
+global $ilDB;
+if ($ilDB->tableExists('xali_data') && $ilDB->tableColumnExists('xali_data', 'activation')) {
+    $ilDB->manipulateF(
+        "UPDATE xali_data SET activation = %s WHERE activation IS NULL",
+        ['integer'],
+        [0]
+    );
+}
+?>


### PR DESCRIPTION
Problem is there might be data in xali_data with column activation = null
But because of PHP8 strict types this has to be an integer.

I created a new update steps to default all nulls to 0.
Also on fresh installation the table will not be nullable

Best @fhelfer 